### PR TITLE
Upgrade Python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use latest support Python version with an Alpine base
-FROM python:3.10-alpine
+# Use Python version 3.12.9 with an Alpine base
+FROM python:3.12.9-alpine3.21
 
 # Set necessary args for building
 # If omitted, the versions are determined from the git tags

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 onions = "onions:main"
 
 [tool.poetry.dependencies]
-python = ">=3.10,<3.11"
+python = ">=3.10,<3.13"
 Jinja2 = ">=2.10"
 importlib_metadata = ">=1.6.0"
 vanguards = "^0.3.1"


### PR DESCRIPTION
Use Python version 3.12.9 with an Alpine base for building the Dockerized Tor service.